### PR TITLE
Improve dashboard fallbacks

### DIFF
--- a/src/components/DriverStandings.jsx
+++ b/src/components/DriverStandings.jsx
@@ -1,8 +1,18 @@
 import { useEffect, useState } from 'react';
 
+const fallbackDrivers = [
+  { Driver: { driverId: 'max_verstappen', familyName: 'Verstappen' }, points: 575 },
+  { Driver: { driverId: 'sergio_perez', familyName: 'Perez' }, points: 285 },
+  { Driver: { driverId: 'lewis_hamilton', familyName: 'Hamilton' }, points: 234 },
+  { Driver: { driverId: 'fernando_alonso', familyName: 'Alonso' }, points: 206 },
+  { Driver: { driverId: 'charles_leclerc', familyName: 'Leclerc' }, points: 206 },
+];
+
 export default function DriverStandings() {
   const [drivers, setDrivers] = useState([]);
+  const [loading, setLoading] = useState(true);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     fetch('https://ergast.com/api/f1/current/driverStandings.json')
       .then((res) => res.json())
@@ -10,13 +20,15 @@ export default function DriverStandings() {
         const standings =
           data.MRData.StandingsTable.StandingsLists[0].DriverStandings;
         setDrivers(standings.slice(0, 5));
+        setLoading(false);
       })
       .catch(() => {
-        setDrivers([]);
+        setDrivers(fallbackDrivers);
+        setLoading(false);
       });
   }, []);
 
-  if (!drivers.length) {
+  if (loading) {
     return <div className="text-center text-gray-500">Loading...</div>;
   }
 

--- a/src/components/UpcomingRaces.jsx
+++ b/src/components/UpcomingRaces.jsx
@@ -1,8 +1,38 @@
 import { useEffect, useState } from 'react';
 
+const fallbackRaces = [
+  {
+    round: 1,
+    Circuit: { Location: { country: 'Bahrain' } },
+    date: '2024-03-02',
+  },
+  {
+    round: 2,
+    Circuit: { Location: { country: 'Saudi Arabia' } },
+    date: '2024-03-09',
+  },
+  {
+    round: 3,
+    Circuit: { Location: { country: 'Australia' } },
+    date: '2024-03-24',
+  },
+  {
+    round: 4,
+    Circuit: { Location: { country: 'Japan' } },
+    date: '2024-04-07',
+  },
+  {
+    round: 5,
+    Circuit: { Location: { country: 'China' } },
+    date: '2024-04-21',
+  },
+];
+
 export default function UpcomingRaces() {
   const [races, setRaces] = useState([]);
+  const [loading, setLoading] = useState(true);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     fetch('https://ergast.com/api/f1/current.json')
       .then((res) => res.json())
@@ -11,13 +41,15 @@ export default function UpcomingRaces() {
         const today = new Date();
         const upcoming = all.filter((r) => new Date(r.date) >= today).slice(0, 5);
         setRaces(upcoming);
+        setLoading(false);
       })
       .catch(() => {
-        setRaces([]);
+        setRaces(fallbackRaces);
+        setLoading(false);
       });
   }, []);
 
-  if (!races.length) {
+  if (loading) {
     return <div className="text-center text-gray-500">Loading...</div>;
   }
 


### PR DESCRIPTION
## Summary
- add fallback data for `DriverStandings` and `UpcomingRaces`
- show loading state only while fetching data

## Testing
- `npm run build --silent`
- `npm test --silent -- -w 0`
